### PR TITLE
Fixed build_tex.py

### DIFF
--- a/notebook/build_tex.py
+++ b/notebook/build_tex.py
@@ -9,12 +9,7 @@ for path, dirs, files in os.walk("./structure"):
         fout_tex = os.path.join("tex", ".".join(f.split(".")[:-1]) + ".tex")
         print(fout_tex)
 
-        try:
-            os.makedirs(os.path.dirname(fout_tex), exist_ok=True)
-            print("Created file", fout_tex)
-        except:
-            print("Couldn't create file", fout_tex)
-            pass
+        os.makedirs(os.path.dirname(fout_tex), exist_ok=True)
 
         dat = [line for line in open(p).read().splitlines()]
 

--- a/notebook/build_tex.py
+++ b/notebook/build_tex.py
@@ -10,7 +10,7 @@ for path, dirs, files in os.walk("./structure"):
         print(fout_tex)
 
         try:
-            os.makedirs(os.path.dirname(fout_tex))
+            os.makedirs(os.path.dirname(fout_tex), exist_ok=True)
             print("Created file", fout_tex)
         except:
             print("Couldn't create file", fout_tex)

--- a/notebook/preprocess.py
+++ b/notebook/preprocess.py
@@ -22,15 +22,8 @@ def generate_codes_and_docs(code_directory="../pvl/abridged"):
                 )
                 print(fout_code, fout_docs)
 
-                try:
-                    os.makedirs(os.path.dirname(fout_code))
-                except Exception:
-                    pass
-
-                try:
-                    os.makedirs(os.path.dirname(fout_docs))
-                except Exception:
-                    pass
+                os.makedirs(os.path.dirname(fout_code), exist_ok=True)
+                os.makedirs(os.path.dirname(fout_docs), exist_ok=True)
 
                 dat = [line for line in open(p).read().splitlines()]
                 docs = []


### PR DESCRIPTION
I just noticed that it doesn't actually make new directories if the directory already exists. Though, its probably not a problem because the contents of the file gets cleared when we write to it.

If this is intended behavior, just kill this branch. If not, preprocess.py probably has the same problem.